### PR TITLE
Bug fix: item frame/armor stand protection

### DIFF
--- a/src/main/java/com/massivecraft/factions/Conf.java
+++ b/src/main/java/com/massivecraft/factions/Conf.java
@@ -411,6 +411,7 @@ public class Conf {
         territoryDenyUseageMaterials.add(Material.BUCKET);
         territoryDenyUseageMaterials.add(Material.WATER_BUCKET);
         territoryDenyUseageMaterials.add(Material.LAVA_BUCKET);
+        territoryDenyUseageMaterials.add(Material.ARMOR_STAND);
 
         territoryProtectedMaterialsWhenOffline.add(Material.WOODEN_DOOR);
         territoryProtectedMaterialsWhenOffline.add(Material.TRAP_DOOR);
@@ -437,6 +438,7 @@ public class Conf {
         territoryDenyUseageMaterialsWhenOffline.add(Material.BUCKET);
         territoryDenyUseageMaterialsWhenOffline.add(Material.WATER_BUCKET);
         territoryDenyUseageMaterialsWhenOffline.add(Material.LAVA_BUCKET);
+		territoryDenyUseageMaterialsWhenOffline.add(Material.ARMOR_STAND);
 
         safeZoneNerfedCreatureTypes.add(EntityType.BLAZE);
         safeZoneNerfedCreatureTypes.add(EntityType.CAVE_SPIDER);

--- a/src/main/java/com/massivecraft/factions/Conf.java
+++ b/src/main/java/com/massivecraft/factions/Conf.java
@@ -438,7 +438,7 @@ public class Conf {
         territoryDenyUseageMaterialsWhenOffline.add(Material.BUCKET);
         territoryDenyUseageMaterialsWhenOffline.add(Material.WATER_BUCKET);
         territoryDenyUseageMaterialsWhenOffline.add(Material.LAVA_BUCKET);
-		territoryDenyUseageMaterialsWhenOffline.add(Material.ARMOR_STAND);
+        territoryDenyUseageMaterialsWhenOffline.add(Material.ARMOR_STAND);
 
         safeZoneNerfedCreatureTypes.add(EntityType.BLAZE);
         safeZoneNerfedCreatureTypes.add(EntityType.CAVE_SPIDER);

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -131,6 +131,34 @@ public class FactionsEntityListener implements Listener {
                     }
                 }
             } else {
+                // Protect armor stands/item frames from being damaged in protected territories
+                if (damagee.getType() == EntityType.ITEM_FRAME || damagee.getType() == EntityType.ARMOR_STAND) {
+                    // Run the check for a player
+                    if (damager instanceof Player) {
+                        // Generate the action message.
+                        String entityAction;
+
+                        if (damagee.getType() == EntityType.ITEM_FRAME) {
+                            entityAction = "item frames";
+                        } else {
+                            entityAction = "armor stands";
+                        }
+
+                        if (!FactionsBlockListener.playerCanBuildDestroyBlock((Player) damager, damagee.getLocation(), "destroy " + entityAction, false)) {
+                            event.setCancelled(true);
+                        }
+                    } else {
+                        // we don't want to let mobs/arrows destroy item frames/armor stands
+						// so we only have to run the check as if there had been an explosion at the damager location
+						if (!this.checkExplosionForBlock(damager, damagee.getLocation().getBlock())) {
+							event.setCancelled(true);
+						}
+                    }
+
+                    // we don't need to go after
+                    return;
+                }
+
                 //this one should trigger if something other than a player takes damage
                 if (damager instanceof Player) {
                     // now itll only go here if the damage is dealt by a player

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -134,9 +134,9 @@ public class FactionsEntityListener implements Listener {
                 // Protect armor stands/item frames from being damaged in protected territories
                 if (damagee.getType() == EntityType.ITEM_FRAME || damagee.getType() == EntityType.ARMOR_STAND) {
                 	// Manage projectiles launched by players
-					if (damager instanceof Projectile && ((Projectile) damager).getShooter() instanceof Entity) {
-						damager = (Entity) ((Projectile) damager).getShooter();
-					}
+                    if (damager instanceof Projectile && ((Projectile) damager).getShooter() instanceof Entity) {
+                        damager = (Entity) ((Projectile) damager).getShooter();
+                    }
 
                     // Run the check for a player
                     if (damager instanceof Player) {
@@ -154,10 +154,10 @@ public class FactionsEntityListener implements Listener {
                         }
                     } else {
                         // we don't want to let mobs/arrows destroy item frames/armor stands
-						// so we only have to run the check as if there had been an explosion at the damager location
-						if (!this.checkExplosionForBlock(damager, damagee.getLocation().getBlock())) {
-							event.setCancelled(true);
-						}
+                        // so we only have to run the check as if there had been an explosion at the damager location
+                        if (!this.checkExplosionForBlock(damager, damagee.getLocation().getBlock())) {
+                            event.setCancelled(true);
+                        }
                     }
 
                     // we don't need to go after

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -133,6 +133,11 @@ public class FactionsEntityListener implements Listener {
             } else {
                 // Protect armor stands/item frames from being damaged in protected territories
                 if (damagee.getType() == EntityType.ITEM_FRAME || damagee.getType() == EntityType.ARMOR_STAND) {
+                	// Manage projectiles launched by players
+					if (damager instanceof Projectile && ((Projectile) damager).getShooter() instanceof Entity) {
+						damager = (Entity) ((Projectile) damager).getShooter();
+					}
+
                     // Run the check for a player
                     if (damager instanceof Player) {
                         // Generate the action message.
@@ -612,6 +617,8 @@ public class FactionsEntityListener implements Listener {
     public void onPaintingPlace(HangingPlaceEvent event) {
         if (!FactionsBlockListener.playerCanBuildDestroyBlock(event.getPlayer(), event.getBlock().getLocation(), "place paintings", false)) {
             event.setCancelled(true);
+            // Fix: update player's inventory to avoid items glitches
+            event.getPlayer().updateInventory();
         }
     }
 

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -675,19 +675,19 @@ public class FactionsPlayerListener implements Listener {
     }
 
     // For disabling interactions with armor stands in another faction's territory
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-	public void onPlayerInteractAtEntity(PlayerInteractAtEntityEvent event) {
-		Entity entity = event.getRightClicked();
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onPlayerInteractAtEntity(PlayerInteractAtEntityEvent event) {
+        Entity entity = event.getRightClicked();
 
-		// only need to check for armor stand and item frames
-		if (entity.getType() != EntityType.ARMOR_STAND) {
-			return;
-		}
+        // only need to check for armor stand and item frames
+        if (entity.getType() != EntityType.ARMOR_STAND) {
+            return;
+        }
 
-		if (!FactionsBlockListener.playerCanBuildDestroyBlock(event.getPlayer(), entity.getLocation(), "use armor stands", false)) {
-			event.setCancelled(true);
-		}
-	}
+        if (!FactionsBlockListener.playerCanBuildDestroyBlock(event.getPlayer(), entity.getLocation(), "use armor stands", false)) {
+            event.setCancelled(true);
+        }
+    }
 
     // for handling people who repeatedly spam attempts to open a door (or similar) in another faction's territory
     private Map<String, InteractAttemptSpam> interactSpammers = new HashMap<>();

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -658,6 +658,36 @@ public class FactionsPlayerListener implements Listener {
         }
     }
 
+    // For disabling interactions with item frames in another faction's territory
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+        // only need to check for item frames
+        if (event.getRightClicked().getType() != EntityType.ITEM_FRAME) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        Entity entity = event.getRightClicked();
+
+        if (!FactionsBlockListener.playerCanBuildDestroyBlock(player, entity.getLocation(), "use item frames", false)) {
+            event.setCancelled(true);
+        }
+    }
+
+    // For disabling interactions with armor stands in another faction's territory
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	public void onPlayerInteractAtEntity(PlayerInteractAtEntityEvent event) {
+		Entity entity = event.getRightClicked();
+
+		// only need to check for armor stand and item frames
+		if (entity.getType() != EntityType.ARMOR_STAND) {
+			return;
+		}
+
+		if (!FactionsBlockListener.playerCanBuildDestroyBlock(event.getPlayer(), entity.getLocation(), "use armor stands", false)) {
+			event.setCancelled(true);
+		}
+	}
 
     // for handling people who repeatedly spam attempts to open a door (or similar) in another faction's territory
     private Map<String, InteractAttemptSpam> interactSpammers = new HashMap<>();


### PR DESCRIPTION
Hello ProSavage,

As explained in the issue #7, there is a bug with **armor stands and item frames which can be damaged and destroyed in protected territories**. This pull request fixes this bug. For doing that, I use your existing methods so I think all cases are properly managed (skeletons/creeper/explosion/usage of a bow). I also added the armor stand material in the default list of denied materials for usage in protected territories.

I hope that this fix will help you to improve the plugin. You can edit the code if you want, it's just a help.

### Few tests I have done with the fix:
* https://i.gyazo.com/5e02d96228e814f8684f3b2f7d480fcd.mp4 (As a player, I can't use/destroy item frames/armor stands)
* https://i.gyazo.com/2b9455dbf6cfa8b8e62be9907a42acae.mp4 (TNTs can destroy item frames/armor stands)
* https://i.gyazo.com/cd1e40d2e8c6a3e6988b11e52ecd23a8.mp4 (skeletons can destroy armor stands)

Thank you for your plugin!
Regards.