### PR TITLE
Bug fix: item frame/armor stand protection #2

### DIFF
--- a/src/main/java/com/massivecraft/factions/Conf.java
+++ b/src/main/java/com/massivecraft/factions/Conf.java
@@ -371,6 +371,7 @@ public class Conf {
         territoryDenyUseageMaterials.add(Material.BUCKET);
         territoryDenyUseageMaterials.add(Material.WATER_BUCKET);
         territoryDenyUseageMaterials.add(Material.LAVA_BUCKET);
+        territoryDenyUseageMaterials.add(Material.ARMOR_STAND);
 
         territoryProtectedMaterialsWhenOffline.add(P.p.WOODEN_DOOR);
         territoryProtectedMaterialsWhenOffline.add(P.p.TRAP_DOOR);
@@ -397,6 +398,7 @@ public class Conf {
         territoryDenyUseageMaterialsWhenOffline.add(Material.BUCKET);
         territoryDenyUseageMaterialsWhenOffline.add(Material.WATER_BUCKET);
         territoryDenyUseageMaterialsWhenOffline.add(Material.LAVA_BUCKET);
+        territoryDenyUseageMaterialsWhenOffline.add(Material.ARMOR_STAND);
 
         safeZoneNerfedCreatureTypes.add(EntityType.BLAZE);
         safeZoneNerfedCreatureTypes.add(EntityType.CAVE_SPIDER);


### PR DESCRIPTION
Hello @ProSavage,

This pull request adds the same code that I have done to fix the item frames / armor stands protection in factions territories few months ago.
I don't known why but you have reverted it on the last 31th of May. You can check it out here #8.

This also adds the armor stand in the protected materials list.
So, **for users**, if your conf.json is already generated, you have to manually add the material in lists *territoryDenyUseageMaterials* and *territoryDenyUseageMaterialsWhenOffline* , like:

![image](https://user-images.githubusercontent.com/9255967/44821564-b2827a00-abf6-11e8-95d9-5dea87740403.png)

Happy to see that this plugin grows every day!
If you have any suggestion, feel free to talk there in comments below.
Regards