### PR TITLE
Fix chat (2nd attempt)

### DIFF
--- a/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
@@ -179,10 +179,6 @@ public class FactionsChatListener implements Listener {
 
         // Relation Colored?
         if (Conf.chatTagRelationColored) {
-            // Messages are sent to players individually
-            // This still leaves a chance for other plugins to pick it up
-            event.setCancelled(true);
-
             for (Player listeningPlayer : event.getRecipients()) {
                 FPlayer you = FPlayers.getInstance().getByPlayer(listeningPlayer);
                 String yourFormat = formatStart + me.getChatTag(you).trim() + formatEnd;
@@ -197,9 +193,9 @@ public class FactionsChatListener implements Listener {
                 }
             }
 
-            // Write to the log... We will write the non colored message.
-            String nonColoredMsg = ChatColor.stripColor(String.format(nonColoredMsgFormat, talkingPlayer.getDisplayName(), msg));
-            Bukkit.getLogger().log(Level.INFO, nonColoredMsg);
+            // Messages are sent to players individually
+            // This still leaves a chance for other plugins to pick it up
+            event.getRecipients().clear();
         }
         // Message with no relation color.
         event.setFormat(nonColoredMsgFormat);


### PR DESCRIPTION
Made a oversight last time, clearing the recipient list right before it's queried again... sorry for the trouble 

Also logging removed because the event isn't cancelled, thus it get's logged normally