### PR TITLE
Protection, Placeholder and fix

### DIFF
--- a/src/main/java/com/massivecraft/factions/SavageFactions.java
+++ b/src/main/java/com/massivecraft/factions/SavageFactions.java
@@ -220,11 +220,11 @@ public class SavageFactions extends MPlugin {
 
         // Register Event Handlers
         eventsListener = new Listener[] {
-    		new FactionsPlayerListener(this),
-    		new FactionsChatListener(this),
-    		new FactionsEntityListener(this),
+    		new FactionsPlayerListener(),
+    		new FactionsChatListener(),
+    		new FactionsEntityListener(),
     		new FactionsExploitListener(),
-    		new FactionsBlockListener(this),
+    		new FactionsBlockListener(),
     		new FUpgradesGUI(),
     		new EXPUpgrade(),
     		new CropUpgrades(),
@@ -528,18 +528,19 @@ public class SavageFactions extends MPlugin {
     
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
-       FPlayer fPlayer = FPlayers.getInstance().getByPlayer((Player) sender);
-    	List<String> completions = new ArrayList<>();
-    	String cmd = Conf.baseCommandAliases.isEmpty() ? "/f" : "/" + Conf.baseCommandAliases.get(0);
-    	List<String> argsList = new ArrayList<>(Arrays.asList(args));
-    	argsList.remove(argsList.size() - 1);
-    	String cmdValid = (cmd + " " + TextUtil.implode(argsList, " ")).trim();
-    	MCommand<?> commandEx = cmdBase;
-    	List<MCommand<?>> commandsList = cmdBase.subCommands;
-       if (Board.getInstance().getFactionAt(new FLocation(fPlayer.getPlayer().getLocation())) == Factions.getInstance().getWarZone()) {
+		FPlayer fPlayer = FPlayers.getInstance().getByPlayer((Player) sender);
+		List<String> completions = new ArrayList<>();
+		String cmd = Conf.baseCommandAliases.isEmpty() ? "/f" : "/" + Conf.baseCommandAliases.get(0);
+		List<String> argsList = new ArrayList<>(Arrays.asList(args));
+		argsList.remove(argsList.size() - 1);
+		String cmdValid = (cmd + " " + TextUtil.implode(argsList, " ")).trim();
+		MCommand<?> commandEx = cmdBase;
+		List<MCommand<?>> commandsList = cmdBase.subCommands;
+		
+		if (Board.getInstance().getFactionAt(new FLocation(fPlayer.getPlayer().getLocation())) == Factions.getInstance().getWarZone()) {
           sender.sendMessage(ChatColor.translateAlternateColorCodes('&', "&cYou cannot use autocomplete in warzone."));
           return new ArrayList<>();
-       }
+        }
 
     	for (; !commandsList.isEmpty() && !argsList.isEmpty(); argsList.remove(0))
     	{

--- a/src/main/java/com/massivecraft/factions/cmd/CmdClaim.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdClaim.java
@@ -3,6 +3,7 @@ package com.massivecraft.factions.cmd;
 import com.massivecraft.factions.Conf;
 import com.massivecraft.factions.FLocation;
 import com.massivecraft.factions.Faction;
+import com.massivecraft.factions.SavageFactions;
 import com.massivecraft.factions.struct.Permission;
 import com.massivecraft.factions.struct.Role;
 import com.massivecraft.factions.util.SpiralTask;
@@ -24,8 +25,7 @@ public class CmdClaim extends FCommand {
         this.permission = Permission.CLAIM.node;
         this.disableOnLock = true;
 
-
-       senderMustBePlayer = true;
+        senderMustBePlayer = true;
         senderMustBeMember = false;
         senderMustBeModerator = false;
         senderMustBeColeader = false;
@@ -46,6 +46,12 @@ public class CmdClaim extends FCommand {
             }
         }
 
+        if (forFaction.isWilderness())
+        {
+        	CmdUnclaim cmdUnclaim = SavageFactions.plugin.cmdBase.cmdUnclaim;
+        	cmdUnclaim.execute(sender, args.size() > 1 ? args.subList(0, 1):args);
+        	return;
+        }
 
         if (radius < 1) {
             msg(TL.COMMAND_CLAIM_INVALIDRADIUS);

--- a/src/main/java/com/massivecraft/factions/cmd/CmdConvert.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdConvert.java
@@ -2,6 +2,7 @@ package com.massivecraft.factions.cmd;
 
 import com.massivecraft.factions.Conf;
 import com.massivecraft.factions.Conf.Backend;
+import com.massivecraft.factions.struct.Permission;
 import com.massivecraft.factions.zcore.persist.json.FactionsJSON;
 import com.massivecraft.factions.zcore.util.TL;
 import org.bukkit.command.ConsoleCommandSender;
@@ -11,6 +12,8 @@ public class CmdConvert extends FCommand {
     public CmdConvert() {
         this.aliases.add("convert");
 
+        this.permission = Permission.CONVERT.node;
+        
         this.requiredArgs.add("[MYSQL|JSON]");
     }
 

--- a/src/main/java/com/massivecraft/factions/cmd/CmdList.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdList.java
@@ -31,8 +31,7 @@ public class CmdList extends FCommand {
         this.permission = Permission.LIST.node;
         this.disableOnLock = false;
 
-
-       senderMustBePlayer = false;
+        senderMustBePlayer = false;
         senderMustBeMember = false;
         senderMustBeModerator = false;
         senderMustBeColeader = false;
@@ -42,9 +41,8 @@ public class CmdList extends FCommand {
     @Override
     public void perform() {
         // if economy is enabled, they're not on the bypass list, and this command has a cost set, make 'em pay
-        if (!payForCommand(Conf.econCostList, "to list the factions", "for listing the factions")) {
+        if (!payForCommand(Conf.econCostList, "to list the factions", "for listing the factions"))
             return;
-        }
 
         ArrayList<Faction> factionList = Factions.getInstance().getAllFactions();
         factionList.remove(Factions.getInstance().getWilderness());
@@ -52,14 +50,14 @@ public class CmdList extends FCommand {
         factionList.remove(Factions.getInstance().getWarZone());
 
         // remove exempt factions
-        if (!fme.getPlayer().hasPermission("factions.show.bypassexempt")) {
+        if (fme != null && fme.getPlayer() != null && !fme.getPlayer().hasPermission("factions.show.bypassexempt")) {
             List<String> exemptFactions = SavageFactions.plugin.getConfig().getStringList("show-exempt");
             Iterator<Faction> factionIterator = factionList.iterator();
+            
             while (factionIterator.hasNext()) {
                 Faction next = factionIterator.next();
-                if (exemptFactions.contains(next.getTag())) {
+                if (exemptFactions.contains(next.getTag()))
                     factionIterator.remove();
-                }
             }
         }
 

--- a/src/main/java/com/massivecraft/factions/cmd/CmdOwner.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdOwner.java
@@ -19,7 +19,7 @@ public class CmdOwner extends FCommand {
         this.disableOnLock = true;
 
 
-       senderMustBePlayer = true;
+        senderMustBePlayer = true;
         senderMustBeMember = false;
         senderMustBeModerator = false;
         senderMustBeColeader = false;
@@ -63,7 +63,6 @@ public class CmdOwner extends FCommand {
                 fme.msg(TL.COMMAND_OWNER_WRONGFACTION);
                 return;
             }
-
         }
 
         FPlayer target = this.argAsBestFPlayerMatch(0, fme);

--- a/src/main/java/com/massivecraft/factions/cmd/CmdSeeChunk.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdSeeChunk.java
@@ -10,10 +10,8 @@ import com.massivecraft.factions.zcore.util.TL;
 import org.bukkit.*;
 import org.bukkit.entity.Player;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 
 public class CmdSeeChunk extends FCommand {
 
@@ -117,7 +115,6 @@ public class CmdSeeChunk extends FCommand {
     }
 
     private void showPillar(Player player, World world, int blockX, int blockZ) {
-        List<Player> onePlayer = Arrays.asList(player);
         for (int blockY = 0; blockY < player.getLocation().getBlockY() + 30; blockY++) {
             Location loc = new Location(world, blockX, blockY, blockZ).add(0.5, 0, 0.5);
             if (loc.getBlock().getType() != Material.AIR) {

--- a/src/main/java/com/massivecraft/factions/cmd/CmdShow.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdShow.java
@@ -47,12 +47,11 @@ public class CmdShow extends FCommand {
     @Override
     public void perform() {
         Faction faction = myFaction;
-        if (this.argIsSet(0)) {
+        if (this.argIsSet(0))
             faction = this.argAsFaction(0);
-        }
-        if (faction == null) {
+        
+        if (faction == null)
             return;
-        }
 
         if (fme != null && !fme.getPlayer().hasPermission("factions.show.bypassexempt")
                 && SavageFactions.plugin.getConfig().getStringList("show-exempt").contains(faction.getTag())) {
@@ -66,9 +65,8 @@ public class CmdShow extends FCommand {
         }
 
         List<String> show = SavageFactions.plugin.getConfig().getStringList("show");
-        if (show == null || show.isEmpty()) {
+        if (show == null || show.isEmpty())
             show = defaults;
-        }
 
         if (!faction.isNormal()) {
             String tag = faction.getTag(fme);
@@ -92,11 +90,11 @@ public class CmdShow extends FCommand {
                 parsed = TagUtil.parsePlaceholders(fme.getPlayer(), parsed);
             }
 
-            if (fme != null && TagUtil.hasFancy(parsed)) {
+            if (TagUtil.hasFancy(parsed)) {
                 List<FancyMessage> fancy = TagUtil.parseFancy(faction, fme, parsed);
-                if (fancy != null) {
+                if (fancy != null)
                     sendFancyMessage(fancy);
-                }
+                
                 continue;
             }
             if (!parsed.contains("{notFrozen}") && !parsed.contains("{notPermanent}")) {

--- a/src/main/java/com/massivecraft/factions/cmd/CmdTpBanner.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdTpBanner.java
@@ -30,7 +30,7 @@ public class CmdTpBanner extends FCommand {
             return;
         }
 
-        final FactionsPlayerListener fpl = new FactionsPlayerListener(SavageFactions.plugin);
+        final FactionsPlayerListener fpl = new FactionsPlayerListener();
 
         if (FactionsBlockListener.bannerLocations.containsKey(fme.getTag())) {
             fme.msg(TL.COMMAND_TPBANNER_SUCCESS);

--- a/src/main/java/com/massivecraft/factions/cmd/CmdUnclaim.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdUnclaim.java
@@ -18,7 +18,6 @@ public class CmdUnclaim extends FCommand {
         this.aliases.add("declaim");
 
         this.optionalArgs.put("radius", "1");
-        this.optionalArgs.put("faction", "your");
 
         this.permission = Permission.UNCLAIM.node;
         this.disableOnLock = true;
@@ -27,14 +26,12 @@ public class CmdUnclaim extends FCommand {
         senderMustBeMember = false;
         senderMustBeModerator = false;
         senderMustBeAdmin = false;
-
     }
 
     @Override
     public void perform() {
         // Read and validate input
         int radius = this.argAsInt(0, 1); // Default to 1
-        final Faction forFaction = this.argAsFaction(1, myFaction); // Default to own
 
         if (!fme.isAdminBypassing()) {
             Access access = myFaction.getAccess(fme, PermissableAction.TERRITORY);

--- a/src/main/java/com/massivecraft/factions/integration/dynmap/EngineDynmap.java
+++ b/src/main/java/com/massivecraft/factions/integration/dynmap/EngineDynmap.java
@@ -637,22 +637,19 @@ public class EngineDynmap {
 
         // Name
         String name = faction.getTag();
-        name = ChatColor.stripColor(name);
-        name = escapeHtml(name);
+        name = escapeHtml(ChatColor.stripColor(name));
         ret = ret.replace("%name%", name);
 
         // Description
         String description = faction.getDescription();
-        description = ChatColor.stripColor(description);
-        description = escapeHtml(description);
+        description = escapeHtml(ChatColor.stripColor(description));
         ret = ret.replace("%description%", description);
 
         // Money
 
         String money = "unavailable";
-        if (Conf.bankEnabled && Conf.dynmapDescriptionMoney) {
+        if (Conf.bankEnabled && Conf.dynmapDescriptionMoney)
             money = String.format("%.2f", Econ.getBalance(faction.getAccountId()));
-        }
         ret = ret.replace("%money%", money);
 
 
@@ -664,9 +661,9 @@ public class EngineDynmap {
         FPlayer playersLeaderObject = faction.getFPlayerAdmin();
         String playersLeader = getHtmlPlayerName(playersLeaderObject);
 
-        ArrayList<FPlayer> playersAdminsList = faction.getFPlayersWhereRole(Role.LEADER);
-        String playersAdminsCount = String.valueOf(playersAdminsList.size());
-        String playersAdmins = getHtmlPlayerString(playersAdminsList);
+        ArrayList<FPlayer> playersCoAdminsList = faction.getFPlayersWhereRole(Role.COLEADER);
+        String playersCoAdminsCount = String.valueOf(playersCoAdminsList.size());
+        String playersCoAdmins = getHtmlPlayerString(playersCoAdminsList);
 
         ArrayList<FPlayer> playersModeratorsList = faction.getFPlayersWhereRole(Role.MODERATOR);
         String playersModeratorsCount = String.valueOf(playersModeratorsList.size());
@@ -677,12 +674,11 @@ public class EngineDynmap {
         String playersNormalsCount = String.valueOf(playersNormalsList.size());
         String playersNormals = getHtmlPlayerString(playersNormalsList);
 
-
         ret = ret.replace("%players%", players);
         ret = ret.replace("%players.count%", playersCount);
         ret = ret.replace("%players.leader%", playersLeader);
-        ret = ret.replace("%players.admins%", playersAdmins);
-        ret = ret.replace("%players.admins.count%", playersAdminsCount);
+        ret = ret.replace("%players.admins%", playersCoAdmins);
+        ret = ret.replace("%players.admins.count%", playersCoAdminsCount);
         ret = ret.replace("%players.moderators%", playersModerators);
         ret = ret.replace("%players.moderators.count%", playersModeratorsCount);
         ret = ret.replace("%players.normals%", playersNormals);

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
@@ -9,6 +9,7 @@ import com.massivecraft.factions.util.Particles.ParticleEffect;
 import com.massivecraft.factions.zcore.fperms.Access;
 import com.massivecraft.factions.zcore.fperms.PermissableAction;
 import com.massivecraft.factions.zcore.util.TL;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -21,6 +22,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.*;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
@@ -33,73 +35,58 @@ import java.util.List;
 public class FactionsBlockListener implements Listener {
 
     public static HashMap<String, Location> bannerLocations = new HashMap<>();
-    public SavageFactions savageFactions;
     private HashMap<String, Boolean> bannerCooldownMap = new HashMap<>();
-
-    public FactionsBlockListener(SavageFactions savageFactions) {
-        this.savageFactions = savageFactions;
-    }
 
     public static boolean playerCanBuildDestroyBlock(Player player, Location location, String action, boolean justCheck) {
         String name = player.getName();
-        if (Conf.playersWhoBypassAllProtection.contains(name)) {
+        
+        if (Conf.playersWhoBypassAllProtection.contains(name))
             return true;
-        }
 
         FPlayer me = FPlayers.getInstance().getById(player.getUniqueId().toString());
-        if (me.isAdminBypassing()) {
+        if (me.isAdminBypassing())
             return true;
-        }
 
         FLocation loc = new FLocation(location);
         Faction otherFaction = Board.getInstance().getFactionAt(loc);
 
         if (otherFaction.isWilderness()) {
-            if (Conf.worldGuardBuildPriority && Worldguard.playerCanBuild(player, location)) {
+            if (Conf.worldGuardBuildPriority && Worldguard.playerCanBuild(player, location))
                 return true;
-            }
 
-            if (!Conf.wildernessDenyBuild || Conf.worldsNoWildernessProtection.contains(location.getWorld().getName())) {
+            if (!Conf.wildernessDenyBuild || Conf.worldsNoWildernessProtection.contains(location.getWorld().getName()))
                 return true; // This is not faction territory. Use whatever you like here.
-            }
 
-            if (!justCheck) {
+            if (!justCheck)
                 me.msg("<b>You can't " + action + " in the wilderness.");
-            }
 
             return false;
         } else if (otherFaction.isSafeZone()) {
-            if (Conf.worldGuardBuildPriority && Worldguard.playerCanBuild(player, location)) {
+            if (Conf.worldGuardBuildPriority && Worldguard.playerCanBuild(player, location))
                 return true;
-            }
 
-            if (!Conf.safeZoneDenyBuild || Permission.MANAGE_SAFE_ZONE.has(player)) {
+            if (!Conf.safeZoneDenyBuild || Permission.MANAGE_SAFE_ZONE.has(player))
                 return true;
-            }
 
-            if (!justCheck) {
+            if (!justCheck)
                 me.msg("<b>You can't " + action + " in a safe zone.");
-            }
 
             return false;
         } else if (otherFaction.isWarZone()) {
-            if (Conf.worldGuardBuildPriority && Worldguard.playerCanBuild(player, location)) {
+            if (Conf.worldGuardBuildPriority && Worldguard.playerCanBuild(player, location))
                 return true;
-            }
 
-            if (!Conf.warZoneDenyBuild || Permission.MANAGE_WAR_ZONE.has(player)) {
+            if (!Conf.warZoneDenyBuild || Permission.MANAGE_WAR_ZONE.has(player))
                 return true;
-            }
 
-            if (!justCheck) {
+            if (!justCheck)
                 me.msg("<b>You can't " + action + " in a war zone.");
-            }
 
             return false;
         }
-        if (SavageFactions.plugin.getConfig().getBoolean("hcf.raidable", false) && otherFaction.getLandRounded() >= otherFaction.getPowerRounded()) {
+        
+        if (SavageFactions.plugin.getConfig().getBoolean("hcf.raidable", false) && otherFaction.getLandRounded() > otherFaction.getPowerRounded())
             return true;
-        }
 
         Faction myFaction = me.getFaction();
         Relation rel = myFaction.getRelationTo(otherFaction);
@@ -108,9 +95,9 @@ public class FactionsBlockListener implements Listener {
         boolean deny = rel.confDenyBuild(online);
 
         Access access = otherFaction.getAccess(me, PermissableAction.fromString(action));
-        if (access == Access.ALLOW && ((rel == Relation.ALLY) || (rel == Relation.ENEMY) || (rel == Relation.NEUTRAL) || (rel == Relation.TRUCE))) {
+        if (access == Access.ALLOW && ((rel == Relation.ALLY) || (rel == Relation.ENEMY) || (rel == Relation.NEUTRAL) || (rel == Relation.TRUCE)))
             deny = false;
-        }
+
         // hurt the player for building/destroying in other territory?
         if (pain) {
             player.damage(Conf.actionDeniedPainAmount);
@@ -151,10 +138,12 @@ public class FactionsBlockListener implements Listener {
         if (access != Access.ALLOW && me.getRole() != Role.LEADER) {
             // TODO: Update this once new access values are added other than just allow / deny.
             if (access == Access.DENY) {
-                me.msg(TL.GENERIC_NOPERMISSION, action);
+            	if (!justCheck)
+            		me.msg(TL.GENERIC_NOPERMISSION, action);
                 return false;
             } else if (myFaction.getOwnerListString(loc) != null && !myFaction.getOwnerListString(loc).isEmpty() && !myFaction.getOwnerListString(loc).contains(player.getName())) {
-                me.msg("<b>You can't " + action + " in this territory, it is owned by: " + myFaction.getOwnerListString(loc));
+            	if (!justCheck)
+            		me.msg("<b>You can't " + action + " in this territory, it is owned by: " + myFaction.getOwnerListString(loc));
                 return false;
             }
         }
@@ -230,7 +219,7 @@ public class FactionsBlockListener implements Listener {
          * only the final target block as done above
          */
     }
-
+    
     @EventHandler
     public void onVaultPlace(BlockPlaceEvent e) {
         if (e.getItemInHand().getType() == Material.CHEST) {
@@ -381,9 +370,9 @@ public class FactionsBlockListener implements Listener {
                     }
                     for (FPlayer fplayer : fme.getFaction().getFPlayers()) {
                         //  if (fplayer == fme) { continue; }   //Idk if I wanna not send the title to the player
-                        fplayer.getPlayer().sendTitle(SavageFactions.plugin.color(fme.getTag() + " Placed A WarBanner!"), SavageFactions.plugin.color("&7use &c/f tpbanner&7 to tp to the banner!"));
-
+                        fplayer.getPlayer().sendTitle(SavageFactions.plugin.color(fme.getTag() + " Placed A WarBanner!"), SavageFactions.plugin.color("&7use &c/f tpbanner&7 to tp to the banner!"), 10, 70, 20);
                     }
+                    
                     bannerCooldownMap.put(fme.getTag(), true);
                     bannerLocations.put(fme.getTag(), e.getBlockPlaced().getLocation());
                     final int bannerCooldown = SavageFactions.plugin.getConfig().getInt("fbanners.Banner-Place-Cooldown");
@@ -515,5 +504,23 @@ public class FactionsBlockListener implements Listener {
                 }
             }
         }
+    }
+    
+    @EventHandler
+    public void onFarmLandDamage(EntityChangeBlockEvent event)
+    {
+    	if (event.getEntity() instanceof Player)
+    	{
+    		Player player = (Player) event.getEntity();
+    		if (!playerCanBuildDestroyBlock(player, event.getBlock().getLocation(), PermissableAction.DESTROY.name(), true))
+    		{
+    			FPlayer me = FPlayers.getInstance().getById(player.getUniqueId().toString());
+    			Faction otherFaction = Board.getInstance().getFactionAt(new FLocation(event.getBlock().getLocation()));
+    			Faction myFaction = me.getFaction();
+    			
+    			me.msg("<b>You can't jump on farmland in the territory of " + otherFaction.getTag(myFaction));
+    			event.setCancelled(true);
+    		}
+    	}
     }
 }

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsChatListener.java
@@ -19,13 +19,6 @@ import java.util.logging.Level;
 
 public class FactionsChatListener implements Listener {
 
-    public SavageFactions savageFactions;
-
-    public FactionsChatListener(SavageFactions savageFactions) {
-        this.savageFactions = savageFactions;
-    }
-
-
     // this is for handling slashless command usage and faction/alliance chat, set at lowest priority so Factions gets to them first
     @EventHandler (priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerEarlyChat(AsyncPlayerChatEvent event) {

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -32,11 +32,6 @@ import java.util.*;
 public class FactionsEntityListener implements Listener {
 
     private static final Set<PotionEffectType> badPotionEffects = new LinkedHashSet<>(Arrays.asList(PotionEffectType.BLINDNESS, PotionEffectType.CONFUSION, PotionEffectType.HARM, PotionEffectType.HUNGER, PotionEffectType.POISON, PotionEffectType.SLOW, PotionEffectType.SLOW_DIGGING, PotionEffectType.WEAKNESS, PotionEffectType.WITHER));
-    public SavageFactions savageFactions;
-
-    public FactionsEntityListener(SavageFactions savageFactions) {
-        this.savageFactions = savageFactions;
-    }
 
     @EventHandler (priority = EventPriority.NORMAL)
     public void onEntityDeath(EntityDeathEvent event) {
@@ -280,7 +275,9 @@ public class FactionsEntityListener implements Listener {
                 targets.add(center.getRelative(0, - 1, 0));
                 targets.add(center.getRelative(1, 0, 0));
                 targets.add(center.getRelative(- 1, 0, 0));
+                
                 for (Block target : targets) {
+                    @SuppressWarnings("deprecation")
                     int id = target.getType().getId();
                     // ignore air, bedrock, water, lava, obsidian, enchanting table, etc.... too bad we can't get a blast resistance value through Bukkit yet
                     if (id != 0 && (id < 7 || id > 11) && id != 49 && id != 90 && id != 116 && id != 119 && id != 120 && id != 130) {

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsExploitListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsExploitListener.java
@@ -18,6 +18,7 @@ public class FactionsExploitListener implements Listener {
         return ((from.getX() > target.getX() && (from.getX() - target.getX() < thickness)) || (target.getX() > from.getX() && (target.getX() - from.getX() < thickness)) || (from.getZ() > target.getZ() && (from.getZ() - target.getZ() < thickness)) || (target.getZ() > from.getZ() && (target.getZ() - from.getZ() < thickness)));
     }
 
+    @SuppressWarnings("deprecation")
     @EventHandler (priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void obsidianGenerator(BlockFromToEvent event) {
         if (!Conf.handleExploitObsidianGenerators) {

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -47,15 +47,13 @@ public class FactionsPlayerListener implements Listener {
 
   HashMap<Player, Boolean> fallMap = new HashMap<>();
 
-  private SavageFactions savageFactions;
   // Holds the next time a player can have a map shown.
   private HashMap<UUID, Long> showTimes = new HashMap<>();
   // for handling people who repeatedly spam attempts to open a door (or similar) in another faction's territory
   private Map<String, InteractAttemptSpam> interactSpammers = new HashMap<>();
 
-  public FactionsPlayerListener(SavageFactions savageFactions) {
-    this.savageFactions = savageFactions;
-    for (Player player : savageFactions.getServer().getOnlinePlayers()) {
+  public FactionsPlayerListener() {
+    for (Player player : SavageFactions.plugin.getServer().getOnlinePlayers()) {
       initPlayer(player);
     }
   }
@@ -90,7 +88,8 @@ public class FactionsPlayerListener implements Listener {
       }
       return false;
     }
-    if (SavageFactions.plugin.getConfig().getBoolean("hcf.raidable", false) && otherFaction.getLandRounded() >= otherFaction.getPowerRounded()) {
+    
+    if (SavageFactions.plugin.getConfig().getBoolean("hcf.raidable", false) && otherFaction.getLandRounded() > otherFaction.getPowerRounded()) {
       return true;
     }
 
@@ -161,16 +160,15 @@ public class FactionsPlayerListener implements Listener {
 
     return true;
   }
+  
   @SuppressWarnings("deprecation")
   public static boolean canPlayerUseBlock(Player player, Block block, boolean justCheck) {
-    if (Conf.playersWhoBypassAllProtection.contains(player.getName())) {
+    if (Conf.playersWhoBypassAllProtection.contains(player.getName()))
       return true;
-    }
 
     FPlayer me = FPlayers.getInstance().getByPlayer(player);
-    if (me.isAdminBypassing()) {
+    if (me.isAdminBypassing())
       return true;
-    }
 
     Material material = block.getType();
     // Dupe fix.
@@ -179,30 +177,17 @@ public class FactionsPlayerListener implements Listener {
     Faction myFaction = me.getFaction();
     Relation rel = myFaction.getRelationTo(otherFaction);
 
-
     // no door/chest/whatever protection in wilderness, war zones, or safe zones
-    if (!otherFaction.isNormal()) {
+    if (!otherFaction.isNormal())
       return true;
-    }
 
-    if (SavageFactions.plugin.getConfig().getBoolean("hcf.raidable", false) && otherFaction.getLandRounded() >= otherFaction.getPowerRounded()) {
+    if (SavageFactions.plugin.getConfig().getBoolean("hcf.raidable", false) && otherFaction.getLandRounded() > otherFaction.getPowerRounded())
       return true;
-    }
 
     if (!rel.isMember() || !otherFaction.playerHasOwnershipRights(me, loc) && player.getItemInHand().getType() != null) {
 
-      if (player.getItemInHand().getType().toString().toUpperCase().contains("DOOR")) {
+      if (player.getItemInHand().getType().toString().toUpperCase().contains("DOOR"))
         return false;
-      }
-
-      switch (player.getItemInHand().getType()) {
-        case CHEST:
-        case TRAPPED_CHEST:
-        case SIGN:
-          return false;
-        default:
-          break;
-      }
     }
 
     PermissableAction action = null;
@@ -212,35 +197,74 @@ public class FactionsPlayerListener implements Listener {
         case LEVER:
           action = PermissableAction.LEVER;
           break;
+        
+        case ACACIA_BUTTON:
+        case BIRCH_BUTTON:
+        case DARK_OAK_BUTTON:
+        case JUNGLE_BUTTON:
+        case OAK_BUTTON:
+        case SPRUCE_BUTTON:
         case STONE_BUTTON:
-        case LEGACY_WOOD_BUTTON:
           action = PermissableAction.BUTTON;
           break;
-        case DARK_OAK_DOOR:
+       
         case ACACIA_DOOR:
         case BIRCH_DOOR:
         case IRON_DOOR:
         case JUNGLE_DOOR:
+        case OAK_DOOR:
         case SPRUCE_DOOR:
-        case LEGACY_TRAP_DOOR:
-        case LEGACY_WOOD_DOOR:
-        case LEGACY_WOODEN_DOOR:
-        case LEGACY_FENCE_GATE:
+        case DARK_OAK_DOOR:
+        
+        case ACACIA_TRAPDOOR:
+        case BIRCH_TRAPDOOR:
+        case DARK_OAK_TRAPDOOR:
+        case IRON_TRAPDOOR:
+        case JUNGLE_TRAPDOOR:
+        case OAK_TRAPDOOR:
+        case SPRUCE_TRAPDOOR:
+        	
         case ACACIA_FENCE_GATE:
         case BIRCH_FENCE_GATE:
         case DARK_OAK_FENCE_GATE:
         case JUNGLE_FENCE_GATE:
+        case OAK_FENCE_GATE:
         case SPRUCE_FENCE_GATE:
           action = PermissableAction.DOOR;
           break;
+        
         case CHEST:
-        case ENDER_CHEST:
         case TRAPPED_CHEST:
+        case CHEST_MINECART:
+        
+        case SHULKER_BOX:
+        case BLACK_SHULKER_BOX:
+        case BLUE_SHULKER_BOX:
+        case BROWN_SHULKER_BOX:
+        case CYAN_SHULKER_BOX:
+        case GRAY_SHULKER_BOX:
+        case GREEN_SHULKER_BOX:
+        case LIGHT_BLUE_SHULKER_BOX:
+        case LIGHT_GRAY_SHULKER_BOX:
+        case LIME_SHULKER_BOX:
+        case MAGENTA_SHULKER_BOX:
+        case ORANGE_SHULKER_BOX:
+        case PINK_SHULKER_BOX:
+        case PURPLE_SHULKER_BOX:
+        case RED_SHULKER_BOX:
+        case WHITE_SHULKER_BOX:
+        case YELLOW_SHULKER_BOX:
+        	
+        case FURNACE:
+        case DROPPER:
         case DISPENSER:
         case ENCHANTING_TABLE:
-        case DROPPER:
-        case FURNACE:
+        case BREWING_STAND:
+        case CAULDRON:
         case HOPPER:
+        case BEACON:
+        case JUKEBOX:
+        
         case ANVIL:
         case CHIPPED_ANVIL:
         case DAMAGED_ANVIL:
@@ -286,35 +310,32 @@ public class FactionsPlayerListener implements Listener {
         case ANVIL:
         case CHIPPED_ANVIL:
         case DAMAGED_ANVIL:
-         case BREWING_STAND:
+        case BREWING_STAND:
           action = PermissableAction.CONTAINER;
           break;
         default:
           // Check for doors that might have diff material name in old version.
-          if (block.getType().name().contains("DOOR")) {
+          if (block.getType().name().contains("DOOR"))
             action = PermissableAction.DOOR;
-          }
           break;
       }
     }
 
     // We only care about some material types.
     if (otherFaction.hasPlayersOnline()) {
-      if (!Conf.territoryProtectedMaterials.contains(material)) {
+      if (!Conf.territoryProtectedMaterials.contains(material))
         return true;
-      }
     } else {
-      if (!Conf.territoryProtectedMaterialsWhenOffline.contains(material)) {
-        return true;
-      }
+      if (!Conf.territoryProtectedMaterialsWhenOffline.contains(material))
+    	  return true;
     }
+    
     // Move up access check to check for exceptions
     Access access = otherFaction.getAccess(me, action);
     boolean doTerritoryEnemyProtectedCheck = true;
 
-
-     if (action != null && action.equals(PermissableAction.CONTAINER) ||
-            (action.equals(PermissableAction.DOOR))) {
+     if (action != null && (action.equals(PermissableAction.CONTAINER) ||
+            action.equals(PermissableAction.DOOR))) {
       if (access == Access.ALLOW) {
         doTerritoryEnemyProtectedCheck = false;
       }
@@ -331,7 +352,6 @@ public class FactionsPlayerListener implements Listener {
         return false;
       }
     }
-
 
     if (access != Access.ALLOW && me.getRole() != Role.LEADER) {
       // TODO: Update this once new access values are added other than just allow / deny.
@@ -542,13 +562,13 @@ public class FactionsPlayerListener implements Listener {
 
   public String parseAllPlaceholders(String string, Faction faction, Player player) {
     string = TagUtil.parsePlaceholders(player, string);
+    
     string = string.replace("{Faction}", faction.getTag())
             .replace("{online}", faction.getOnlinePlayers().size() + "")
             .replace("{offline}", faction.getFPlayers().size() - faction.getOnlinePlayers().size() + "")
             .replace("{chunks}", faction.getAllClaims().size() + "")
             .replace("{power}", faction.getPower() + "")
             .replace("{leader}", faction.getFPlayerAdmin() + "");
-
 
     return string;
   }
@@ -775,12 +795,9 @@ public class FactionsPlayerListener implements Listener {
   @EventHandler
   public void onClose(InventoryCloseEvent e) {
     FPlayer fme = FPlayers.getInstance().getById(e.getPlayer().getUniqueId().toString());
-    if (fme.isInVault()) {
-      fme.setInVault(false);
-    }
-
+    if (fme.isInVault())
+    	fme.setInVault(false);
   }
-
 
   @EventHandler (priority = EventPriority.NORMAL, ignoreCancelled = true)
   public void onPlayerInteract(PlayerInteractEvent event) {
@@ -803,16 +820,14 @@ public class FactionsPlayerListener implements Listener {
             }
         }*/
     // only need to check right-clicks and physical as of MC 1.4+; good performance boost
-    if (event.getAction() != Action.RIGHT_CLICK_BLOCK && event.getAction() != Action.PHYSICAL) {
+    if (event.getAction() != Action.RIGHT_CLICK_BLOCK && event.getAction() != Action.PHYSICAL)
       return;
-    }
 
     Block block = event.getClickedBlock();
     Player player = event.getPlayer();
 
-    if (block == null) {
+    if (block == null)
       return;  // clicked in air, apparently
-    }
 
     if (!canPlayerUseBlock(player, block, false)) {
       event.setCancelled(true);
@@ -823,6 +838,7 @@ public class FactionsPlayerListener implements Listener {
           attempt = new InteractAttemptSpam();
           interactSpammers.put(name, attempt);
         }
+        
         int count = attempt.increment();
         if (count >= 10) {
           FPlayer me = FPlayers.getInstance().getByPlayer(player);
@@ -840,6 +856,26 @@ public class FactionsPlayerListener implements Listener {
     if (!playerCanUseItemHere(player, block.getLocation(), event.getMaterial(), false)) {
       event.setCancelled(true);
     }
+  }
+  
+  @EventHandler
+  public void onPlayerBoneMeal(PlayerInteractEvent event)
+  {
+	  Block block = event.getClickedBlock();
+	  
+	  if (event.getAction() == Action.RIGHT_CLICK_BLOCK && block.getType() == Material.GRASS_BLOCK
+			  && event.hasItem() && event.getItem().getType() == Material.BONE_MEAL)
+	  {
+		  if (!FactionsBlockListener.playerCanBuildDestroyBlock(event.getPlayer(), block.getLocation(), PermissableAction.BUILD.name(), true))
+		  {
+			  FPlayer me = FPlayers.getInstance().getById(event.getPlayer().getUniqueId().toString());
+			  Faction otherFaction = Board.getInstance().getFactionAt(new FLocation(block.getLocation()));
+			  Faction myFaction = me.getFaction();
+			  
+			  me.msg("<b>You can't use bone meal in the territory of " + otherFaction.getTag(myFaction));
+			  event.setCancelled(true);
+		  }
+	  }
   }
 
   @EventHandler (priority = EventPriority.HIGH)

--- a/src/main/java/com/massivecraft/factions/skript/expressions/player/PlayerFactionExpression.java
+++ b/src/main/java/com/massivecraft/factions/skript/expressions/player/PlayerFactionExpression.java
@@ -35,6 +35,7 @@ public class PlayerFactionExpression extends SimpleExpression<String> {
       return true;
    }
 
+   @SuppressWarnings("unchecked")
    @Override
    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parser) {
       playerExpression = (Expression<Player>) exprs[0];
@@ -88,6 +89,7 @@ public class PlayerFactionExpression extends SimpleExpression<String> {
             }
             fPlayer.setFaction(faction);
             break;
+         default:
       }
 
    }

--- a/src/main/java/com/massivecraft/factions/skript/expressions/player/PlayerPowerExpression.java
+++ b/src/main/java/com/massivecraft/factions/skript/expressions/player/PlayerPowerExpression.java
@@ -33,6 +33,7 @@ public class PlayerPowerExpression extends SimpleExpression<Number> {
       return true;
    }
 
+   @SuppressWarnings("unchecked")
    @Override
    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parser) {
       playerExpression = (Expression<Player>) exprs[0];
@@ -84,6 +85,7 @@ public class PlayerPowerExpression extends SimpleExpression<Number> {
          case RESET:
             fPlayer.alterPower(fPlayer.getPowerMax() * -1);
             break;
+         default:
       }
 
 

--- a/src/main/java/com/massivecraft/factions/skript/expressions/player/PlayerRoleExpression.java
+++ b/src/main/java/com/massivecraft/factions/skript/expressions/player/PlayerRoleExpression.java
@@ -33,6 +33,7 @@ public class PlayerRoleExpression extends SimpleExpression<String> {
       return true;
    }
 
+   @SuppressWarnings("unchecked")
    @Override
    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parser) {
       playerExpression = (Expression<Player>) exprs[0];
@@ -82,6 +83,7 @@ public class PlayerRoleExpression extends SimpleExpression<String> {
          case SET:
             fPlayer.setRole(Role.fromString(((String) delta[0]).toLowerCase()));
             break;
+         default:
       }
 
    }

--- a/src/main/java/com/massivecraft/factions/struct/Permission.java
+++ b/src/main/java/com/massivecraft/factions/struct/Permission.java
@@ -22,6 +22,7 @@ public enum Permission {
     CLAIM_LINE("claim.line"),
     CLAIM_RADIUS("claim.radius"),
     CONFIG("config"),
+    CONVERT("convert"),
     CREATE("create"),
     DEFAULTRANK("defaultrank"),
     DEINVITE("deinvite"),

--- a/src/main/java/com/massivecraft/factions/util/ClipPlaceholderAPIManager.java
+++ b/src/main/java/com/massivecraft/factions/util/ClipPlaceholderAPIManager.java
@@ -155,7 +155,9 @@ public class ClipPlaceholderAPIManager extends PlaceholderExpansion implements R
                 return String.valueOf(faction.getDeaths());
             case "faction_maxvaults":
                 return String.valueOf(faction.getMaxVaults());
-
+            case "faction_name_at_location":
+            	Faction factionAtLocation = Board.getInstance().getFactionAt(new FLocation(player.getLocation()));
+            	return factionAtLocation != null ? factionAtLocation.getTag():Factions.getInstance().getWilderness().getTag();
         }
 
         return null;

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryBoard.java
@@ -289,6 +289,7 @@ public abstract class MemoryBoard extends Board {
         return Arrays.asList(faction.describeTo(to));
     }
 
+    @SuppressWarnings("unused")
     private List<String> getToolTip(Faction faction, FPlayer to) {
         List<String> ret = new ArrayList<>();
         List<String> show = SavageFactions.plugin.getConfig().getStringList("map");

--- a/src/main/java/com/massivecraft/factions/zcore/util/TagReplacer.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TagReplacer.java
@@ -184,6 +184,7 @@ public enum TagReplacer {
                 default:
             }
         }
+        
         switch (this) {
             case DESCRIPTION:
                 return fac.getDescription();
@@ -242,7 +243,7 @@ public enum TagReplacer {
                     return String.valueOf(fac.getFPlayersWhereOnline(true, fp).size());
                 } else {
                     // Only console should ever get here.
-                    return String.valueOf(fac.getFPlayers().size());
+                    return String.valueOf(fac.getFPlayersWhereOnline(true).size());
                 }
             case OFFLINE_COUNT:
                 return String.valueOf(fac.getFPlayers().size() - fac.getOnlinePlayers().size());

--- a/src/main/java/com/massivecraft/factions/zcore/util/TagUtil.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TagUtil.java
@@ -5,6 +5,7 @@ import com.massivecraft.factions.FPlayer;
 import com.massivecraft.factions.Faction;
 import com.massivecraft.factions.Factions;
 import com.massivecraft.factions.SavageFactions;
+import com.massivecraft.factions.struct.Relation;
 import com.massivecraft.factions.util.MiscUtil;
 import me.clip.placeholderapi.PlaceholderAPI;
 import mkremins.fanciful.FancyMessage;
@@ -146,7 +147,7 @@ public class TagUtil {
                     String s = otherFaction.getTag(fme);
                     if (otherFaction.getRelationTo(target).isAlly()) {
                         currentAllies.then(firstAlly ? s : ", " + s);
-                        currentAllies.tooltip(tipFaction(otherFaction)).color(fme.getColorTo(otherFaction));
+                        currentAllies.tooltip(tipFaction(otherFaction)).color(fme != null ? fme.getColorTo(otherFaction):Relation.NEUTRAL.getColor());
                         firstAlly = false;
                         if (currentAllies.toJSONString().length() > ARBITRARY_LIMIT) {
                             fancyMessages.add(currentAllies);
@@ -166,7 +167,7 @@ public class TagUtil {
                     String s = otherFaction.getTag(fme);
                     if (otherFaction.getRelationTo(target).isEnemy()) {
                         currentEnemies.then(firstEnemy ? s : ", " + s);
-                        currentEnemies.tooltip(tipFaction(otherFaction)).color(fme.getColorTo(otherFaction));
+                        currentEnemies.tooltip(tipFaction(otherFaction)).color(fme != null ? fme.getColorTo(otherFaction):Relation.NEUTRAL.getColor());
                         firstEnemy = false;
                         if (currentEnemies.toJSONString().length() > ARBITRARY_LIMIT) {
                             fancyMessages.add(currentEnemies);
@@ -186,7 +187,7 @@ public class TagUtil {
                     String s = otherFaction.getTag(fme);
                     if (otherFaction.getRelationTo(target).isTruce()) {
                         currentTruces.then(firstTruce ? s : ", " + s);
-                        currentTruces.tooltip(tipFaction(otherFaction)).color(fme.getColorTo(otherFaction));
+                        currentTruces.tooltip(tipFaction(otherFaction)).color(fme != null ? fme.getColorTo(otherFaction):Relation.NEUTRAL.getColor());
                         firstTruce = false;
                         if (currentTruces.toJSONString().length() > ARBITRARY_LIMIT) {
                             fancyMessages.add(currentTruces);
@@ -200,12 +201,12 @@ public class TagUtil {
                 FancyMessage currentOnline = SavageFactions.plugin.txt.parseFancy(prefix);
                 boolean firstOnline = true;
                 for (FPlayer p : MiscUtil.rankOrder(target.getFPlayersWhereOnline(true, fme))) {
-                    if (fme.getPlayer() != null && !fme.getPlayer().canSee(p.getPlayer())) {
+                    if (fme != null && fme.getPlayer() != null && !fme.getPlayer().canSee(p.getPlayer())) {
                         continue; // skip
                     }
                     String name = p.getNameAndTitle();
                     currentOnline.then(firstOnline ? name : ", " + name);
-                    currentOnline.tooltip(tipPlayer(p)).color(fme.getColorTo(p));
+                    currentOnline.tooltip(tipPlayer(p)).color(fme != null ? fme.getColorTo(p):Relation.NEUTRAL.getColor());
                     firstOnline = false;
                     if (currentOnline.toJSONString().length() > ARBITRARY_LIMIT) {
                         fancyMessages.add(currentOnline);
@@ -220,9 +221,9 @@ public class TagUtil {
                 for (FPlayer p : MiscUtil.rankOrder(target.getFPlayers())) {
                     String name = p.getNameAndTitle();
                     // Also make sure to add players that are online BUT can't be seen.
-                    if (!p.isOnline() || (fme.getPlayer() != null && p.isOnline() && !fme.getPlayer().canSee(p.getPlayer()))) {
+                    if (!p.isOnline() || (fme != null && fme.getPlayer() != null && !fme.getPlayer().canSee(p.getPlayer()))) {
                         currentOffline.then(firstOffline ? name : ", " + name);
-                        currentOffline.tooltip(tipPlayer(p)).color(fme.getColorTo(p));
+                        currentOffline.tooltip(tipPlayer(p)).color(fme != null ? fme.getColorTo(p):Relation.NEUTRAL.getColor());
                         firstOffline = false;
                         if (currentOffline.toJSONString().length() > ARBITRARY_LIMIT) {
                             fancyMessages.add(currentOffline);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -106,7 +106,7 @@ tooltips:
   - "&6&l* &eRank: &7{group}"
   - "&6&l* &eBalance: &7${balance}"
   - "&6&l* &eLast Seen:&7 {lastSeen}"
-  - "&6&l* &ePower: &7{power}/{maxPower}"
+  - "&6&l* &ePower: &7{player-power}/{player-maxpower}"
 
 # Configuration section for Scoreboards
 # This will allow you to completely customize how your scoreboards look.
@@ -1013,6 +1013,8 @@ MassiveStats: true
 #  - {name}      : Players name
 #  - {lastSeen}  : Last time player was seen (if offline), or just 'Online'
 #  - {balance} : Players balance
+#  - {player-power} : Player power
+#  - {player-maxpower} : Player max power
 #  - {player-kills} : # of kills the player has
 #  - {player-deaths}: # of deaths the player has
 # Faction variables. Can be used in tooltips.list, scoreboards, or /f show

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,6 +15,7 @@ permissions:
     children:
       factions.kit.mod: true
       factions.config: true
+      factions.convert: true
       factions.lock: true
       factions.reload: true
       factions.save: true
@@ -133,6 +134,8 @@ permissions:
     description: claim land in a large radius
   factions.config:
     description: change a conf.json setting
+  factions.convert:
+    description: change a backend storage
   factions.create:
     description: create a new faction
   factions.deinvite:


### PR DESCRIPTION
Add :
- PlaceHolder %faction_name_at_location%
- Add protection with farm land
- Add protection to shulkers, to beacon, cauldron and brewing stand
- Add protection with bone meal
- Convert permission for the command

Fix :
- Console /f list
- Console /f show
- Claim with Wilderness is unclaim the land
- Dynmap players.admins and players.admins.count is for co-leader. The leader already have players.leader and a faction have one leader only

Optimization

Tested on Minecraft v1.13.2 with Paper #439