### PR TITLE
Fix NoSuchFieldError (GRASS_BLOCK) on <1.13

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/FRelationCommand.java
+++ b/src/main/java/com/massivecraft/factions/cmd/FRelationCommand.java
@@ -110,7 +110,7 @@ public abstract class FRelationCommand extends FCommand {
                     msg(TL.COMMAND_RELATIONS_EXCEEDS_ME, max, targetRelation.getPluralTranslation());
                     return true;
                 }
-                if (them.getRelationCount(targetRelation) > max) {
+                if (them.getRelationCount(targetRelation) >= max) {
                     msg(TL.COMMAND_RELATIONS_EXCEEDS_THEY, max, targetRelation.getPluralTranslation());
                     return true;
                 }

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -951,7 +951,7 @@ public class FactionsPlayerListener implements Listener {
     public void onPlayerBoneMeal(PlayerInteractEvent event) {
         Block block = event.getClickedBlock();
 
-        if (event.getAction() == Action.RIGHT_CLICK_BLOCK && block.getType() == Material.GRASS_BLOCK
+        if (event.getAction() == Action.RIGHT_CLICK_BLOCK && block.getType() == MultiversionMaterials.GRASS_BLOCK.parseMaterial()
                 && event.hasItem() && event.getItem().getType() == Material.BONE_MEAL) {
             if (!FactionsBlockListener.playerCanBuildDestroyBlock(event.getPlayer(), block.getLocation(), PermissableAction.BUILD.name(), true)) {
                 FPlayer me = FPlayers.getInstance().getById(event.getPlayer().getUniqueId().toString());


### PR DESCRIPTION



**What type of PR is this?**  Bug Fix
**Link to relevant issue number(s), if any:** To fix this issue: https://github.com/ProSavage/SavageFactions/issues/97

**Explain your change(s):** GRASS_BLOCK is non existant in versions prior to 1.13, so I made it compatible to <1.13 versions

**Why did you make these change(s)?** Because of this error spam in console https://pastebin.com/GeskSHNh

**Is there anything we need to know for compatability?** nope
