### PR TITLE
Fix misleading comment on title time

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1018,7 +1018,7 @@ fbanners:
 #Title when moving between chunks
 Title:
   Show-Title: true
-  # You can configure the time in 1.9 or higher! The values are in seconds
+  # You can configure the time in 1.9 or higher! The values are in ticks (20 ticks = 1 second)
   Options:
     FadeInTime: 1
     ShowTime: 10


### PR DESCRIPTION
**What type of PR is this?** Typo

**Explain your change(s):** Title fadein, show and fadeout times are in ticks, but the config says it's in seconds. Updated the comment.

**Why did you make these change(s)?** Because it can be confusing to some users.

**Is there anything we need to know for compatability?** nope
