### PR TITLE
Minor translations for some action messages

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/FCommand.java
+++ b/src/main/java/com/massivecraft/factions/cmd/FCommand.java
@@ -99,7 +99,7 @@ public abstract class FCommand extends MCommand<SavageFactions> {
 
 		if (!fme.hasFaction()) {
 			if (informSenderIfNot) {
-				sender.sendMessage(p.txt.parse("<b>You are not member of any faction."));
+				sender.sendMessage(p.txt.parse(TL.ACTIONS_NOFACTION.toString()));
 			}
 			return false;
 		}
@@ -107,21 +107,21 @@ public abstract class FCommand extends MCommand<SavageFactions> {
 
 		if (this.senderMustBeModerator && !fme.getRole().isAtLeast(Role.MODERATOR)) {
 			if (informSenderIfNot) {
-				sender.sendMessage(p.txt.parse("<b>Only faction moderators can %s.", this.getHelpShort()));
+				sender.sendMessage(p.txt.parse(TL.ACTIONS_MUSTBE.toString().replace("{role}", "moderator").replace("{action}", this.getHelpShort())));
 			}
 			return false;
 		}
 
 		if (this.senderMustBeColeader && !fme.getRole().isAtLeast(Role.COLEADER)) {
 			if (informSenderIfNot) {
-				sender.sendMessage(p.txt.parse("<b>Only faction coleaders can %s.", this.getHelpShort()));
+				sender.sendMessage(p.txt.parse(TL.ACTIONS_MUSTBE.toString().replace("{role}", "coleader").replace("{action}", this.getHelpShort())));
 			}
 			return false;
 		}
 
 		if (this.senderMustBeAdmin && !fme.getRole().isAtLeast(Role.LEADER)) {
 			if (informSenderIfNot) {
-				sender.sendMessage(p.txt.parse("<b>Only faction admins can %s.", this.getHelpShort()));
+				sender.sendMessage(p.txt.parse(TL.ACTIONS_MUSTBE.toString().replace("{role}", "admin").replace("{action}", this.getHelpShort())));
 			}
 			return false;
 		}
@@ -140,7 +140,7 @@ public abstract class FCommand extends MCommand<SavageFactions> {
 		}
 
 		if (!fme.hasFaction()) {
-			sendMessage("You are not member of any faction.");
+			msg(TL.ACTIONS_NOFACTION);
 			return false;
 		}
 		return true;
@@ -152,7 +152,7 @@ public abstract class FCommand extends MCommand<SavageFactions> {
 		}
 
 		if (fme.getRole().value < role.value) {
-			msg("<b>You <h>must be " + role + "<b> to " + this.getHelpShort() + ".");
+			msg(TL.ACTIONS_MUSTBE.toString().replace("{role}", role.nicename).replace("{action}", this.getHelpShort()));
 			return false;
 		}
 		return true;
@@ -282,23 +282,23 @@ public abstract class FCommand extends MCommand<SavageFactions> {
 		}
 
 		if (you.getRole().equals(Role.LEADER)) {
-			i.sendMessage(p.txt.parse("<b>Only the faction admin can do that."));
+			i.sendMessage(p.txt.parse(TL.ACTIONS_MUSTBE.toString().replace("{role}", "leader").replace("{action}", "do that")));
 
 		} else if ((you.getRole().equals(Role.COLEADER))) {
 			if (i == you) {
 				return true;
 			} else {
-				i.sendMessage(p.txt.parse("<b>Coleaders can't control each other..."));
+				i.sendMessage(p.txt.parse(TL.ACTIONS_NOSAMEROLE.toString().replace("{role}", i.getRole().nicename)));
 			}
 
 		} else if (i.getRole().equals(Role.MODERATOR)) {
 			if (i == you) {
 				return true; //Moderators can control themselves
 			} else {
-				i.sendMessage(p.txt.parse("<b>Moderators can't control each other..."));
+				i.sendMessage(p.txt.parse(TL.ACTIONS_NOSAMEROLE.toString().replace("{role}", i.getRole().nicename)));
 			}
 		} else {
-			i.sendMessage(p.txt.parse("<b>You must be a faction moderator to do that."));
+			i.sendMessage(p.txt.parse(TL.ACTIONS_MUSTBE.toString().replace("{role}", "moderator").replace("{action}", "do that")));
 		}
 
 		return false;

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
@@ -487,31 +487,31 @@ public class FactionsBlockListener implements Listener {
 		boolean landOwned = (myFaction.doesLocationHaveOwnersSet(loc) && !myFaction.getOwnerList(loc).isEmpty());
 		if ((landOwned && myFaction.getOwnerListString(loc).contains(player.getName())) || (me.getRole() == Role.LEADER && me.getFactionId().equals(myFaction.getId()))) return true;
 		else if (landOwned && !myFaction.getOwnerListString(loc).contains(player.getName())) {
-			me.msg("<b>You can't " + action + " in this territory, it is owned by: " + myFaction.getOwnerListString(loc));
+			me.msg(TL.ACTIONS_OWNEDTERRITORYDENY.toString().replace("{owners}", myFaction.getOwnerListString(loc)));
 			if (shouldHurt) {
 				player.damage(Conf.actionDeniedPainAmount);
-				me.msg("<b>It is painful to try to " + action + " in the territory of " + Board.getInstance().getFactionAt(loc).getTag(myFaction));
+				me.msg(TL.ACTIONS_NOPERMISSIONPAIN.toString().replace("{action}", action.toString()).replace("{faction}", Board.getInstance().getFactionAt(loc).getTag(myFaction)));
 			}
 			return false;
 		} else if (!landOwned && access == Access.DENY) { // If land is not owned but access is set to DENY anyway
 			if (shouldHurt) {
 				player.damage(Conf.actionDeniedPainAmount);
-				me.msg("<b>It is painful to try to " + action + " in the territory of " + Board.getInstance().getFactionAt(loc).getTag(myFaction));
+				me.msg(TL.ACTIONS_NOPERMISSIONPAIN.toString().replace("{action}", action.toString()).replace("{faction}", Board.getInstance().getFactionAt(loc).getTag(myFaction)));
 			}
-			me.msg("You cannot " + action + " in the territory of " + myFaction.getTag(me.getFaction()));
+			me.msg(TL.ACTIONS_NOPERMISSION.toString().replace("{faction}", myFaction.getTag(me.getFaction())).replace("{action}", action.toString()));
 			return false;
 		} else if (access == Access.ALLOW) return true;
-		me.msg("You cannot " + action + " in the territory of " + myFaction.getTag(me.getFaction()));
+		me.msg(TL.ACTIONS_NOPERMISSION.toString().replace("{faction}", myFaction.getTag(me.getFaction())).replace("{action}", action.toString()));
 		return false;
 	}
 
 	private static boolean CheckActionState(Faction target, FLocation location, FPlayer me, PermissableAction action, boolean pain) {
 		if (Conf.ownedAreasEnabled && target.doesLocationHaveOwnersSet(location) && !target.playerHasOwnershipRights(me, location)) {
 			// If pain should be applied
-			if (pain && Conf.ownedAreaPainBuild) me.msg("<b>It is painful to try to " + action + " in this territory, it is owned by: " + target.getOwnerListString(location));
+			if (pain && Conf.ownedAreaPainBuild) me.msg(TL.ACTIONS_OWNEDTERRITORYPAINDENY.toString().replace("{action}", action.toString()).replace("{faction}", target.getOwnerListString(location)));
 			if (Conf.ownedAreaDenyBuild && pain) return false;
 			else if (Conf.ownedAreaDenyBuild) {
-				me.msg("You cannot " + action + " in the territory of " + target.getTag(me.getFaction()));
+				me.msg(TL.ACTIONS_NOPERMISSION.toString().replace("{faction}", target.getTag(me.getFaction())).replace("{action}", action.toString()));
 				return false;
 			}
 		}

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -40,7 +40,6 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.*;
-import org.bukkit.util.NumberConversions;
 
 import java.util.*;
 import java.util.logging.Level;
@@ -88,7 +87,7 @@ public class FactionsPlayerListener implements Listener {
 		// Also cancel if player doesn't have ownership rights for this claim
 		if (Conf.ownedAreasEnabled && myFaction == otherFaction && !myFaction.playerHasOwnershipRights(me, loc)) {
 			if (!justCheck) {
-				me.msg("<b>You can't use that in this territory, it is owned by: " + otherFaction.getOwnerListString(loc));
+				me.msg(TL.ACTIONS_OWNEDTERRITORYDENY.toString().replace("{owners}", myFaction.getOwnerListString(loc)));
 			}
 			return false;
 		}
@@ -773,7 +772,7 @@ public class FactionsPlayerListener implements Listener {
 				Faction otherFaction = Board.getInstance().getFactionAt(new FLocation(block.getLocation()));
 				Faction myFaction = me.getFaction();
 
-				me.msg("<b>You can't use bone meal in the territory of " + otherFaction.getTag(myFaction));
+				me.msg(TL.ACTIONS_NOPERMISSION.toString().replace("{faction}", myFaction.getTag(me.getFaction())).replace("{action}", "use bone meal"));
 				event.setCancelled(true);
 			}
 		}
@@ -898,18 +897,18 @@ public class FactionsPlayerListener implements Listener {
 			boolean landOwned = (myFaction.doesLocationHaveOwnersSet(loc) && !myFaction.getOwnerList(loc).isEmpty());
 			if ((landOwned && myFaction.getOwnerListString(loc).contains(player.getName())) || (me.getRole() == Role.LEADER && me.getFactionId().equals(myFaction.getId()))) return true;
 			else if (landOwned && !myFaction.getOwnerListString(loc).contains(player.getName())) {
-				me.msg("<b>You can't do that in this territory, it is owned by: " + myFaction.getOwnerListString(loc));
+				me.msg(TL.ACTIONS_OWNEDTERRITORYDENY.toString().replace("{owners}", myFaction.getOwnerListString(loc)));
 				if (doPain) {
 					player.damage(Conf.actionDeniedPainAmount);
 				}
 				return false;
 			} else if (!landOwned && access == Access.ALLOW) return true;
 			else {
-				me.msg("You cannot " + action + " in the territory of " + myFaction.getTag(me.getFaction()));
+				me.msg(TL.ACTIONS_NOPERMISSION.toString().replace("{faction}", myFaction.getTag(me.getFaction())).replace("{action}", action.toString()));
 				return false;
 			}
 		}
-		me.msg("You cannot " + action + " in the territory of " + myFaction.getTag(me.getFaction()));
+		me.msg(TL.ACTIONS_NOPERMISSION.toString().replace("{faction}", myFaction.getTag(me.getFaction())).replace("{action}", action.toString()));
 		return false;
 	}
 	/// <summary>
@@ -918,6 +917,9 @@ public class FactionsPlayerListener implements Listener {
 	private static PermissableAction GetPermissionFromUsableBlock(Block block) {
 		return GetPermissionFromUsableBlock(block.getType());
 	}
+	/// <summary>
+	/// This will try to resolve a permission action based on the item material, if it's not usable, will return null
+	/// <summary>
 	private static PermissableAction GetPermissionFromUsableBlock(Material material) {
 		// Check for doors that might have diff material name in old version.
 		if (material.name().contains("DOOR"))

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -46,7 +46,16 @@ public enum TL {
 	_LOCAL_LANGUAGE("English"),
 	_LOCAL_REGION("US"),
 	_LOCAL_STATE("complete"), //And this is the English version. It's not ever going to be not complete.
-
+	/**
+	 * Actions translations
+	 */
+	ACTIONS_NOPERMISSION("<b>{faction} does not allow you to {action}</b>"),
+	ACTIONS_NOPERMISSIONPAIN("<b>It is painful to try to {action} in the territory of {faction}</b>"),
+	ACTIONS_OWNEDTERRITORYDENY("<b>You cant do that in this territory, it is owned by {owners}</b>"),
+	ACTIONS_OWNEDTERRITORYPAINDENY("<b>It is painful to try to {action} in this territory, it is owned by {owners}"),
+	ACTIONS_MUSTBE("<b>You </b><h>must be {role}</h><b> to {action}.</b>"),
+	ACTIONS_NOSAMEROLE("<b>{role} can't control each other...</b>"),
+	ACTIONS_NOFACTION("You are not member of any faction."),
 	/**
 	 * Command translations
 	 */

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -476,6 +476,14 @@ COMPASS:
     EAST: E
     SOUTH: S
     WEST: W
+ACTIONS:
+  NOPERMISSION: '<b>{faction} does not allow you to {action}</b>'
+  NOPERMISSIONPAINFUL: '<b>It is painful to try to {action} in the territory of {faction}</b>'
+  OWNEDTERRITORYDENY: <b>You cant do that in this territory, it is owned by {owners}</b>
+  OWNEDTERRITORYPAINDENY: <b>It is painful to try to {action} in this territory, it is owned by {owners}</b>
+  MUSTBE: '<b>You </b><h>must be {role}</h><b> to {action}.</b>'
+  NOSAMEROLE: <b>{role} can't control each other...</b>
+  NOFACTION: 'You are not member of any faction.'
 CHAT:
   FACTION: faction chat
   ALLIANCE: alliance chat


### PR DESCRIPTION
## Pull Request to add Translation

This pull requests set ups various messages to be available in translation files.

### Relevant Issues

There's one issue which this pull request has addressed from:

#124 Although this doesn't completely get rid of hard coded messages, it is a step forward.

### What has changed

All of the changes consist in localized (variables) strings that allows translations in different messages that are shown when certain actions are executed, some of this includes:
- Message that were triggered when a player did not have permissions to build in land.
- Message that were triggered when a player did not have permissions to destroy in land.
- Message that were triggered when a player did not have permissions to use items in land.
- Messages that were triggered in some faction commands.

### Before updating

Please note that this pull request does not contain any possible break, but you will most likely need to add the new translations to the language file of your need.