### PR TITLE
PowerRegenEvent

### DIFF
--- a/src/main/java/com/massivecraft/factions/event/PowerRegenEvent.java
+++ b/src/main/java/com/massivecraft/factions/event/PowerRegenEvent.java
@@ -10,9 +10,19 @@ import org.bukkit.event.Cancellable;
 public class PowerRegenEvent extends FactionPlayerEvent implements Cancellable {
 
     private boolean cancelled = false;
+    private double delta;
 
-    public PowerRegenEvent(Faction f, FPlayer p) {
+    public PowerRegenEvent(Faction f, FPlayer p, double delta) {
         super(f, p);
+        this.delta = delta;
+    }
+
+    public double getDelta() {
+        return delta;
+    }
+
+    public void setDelta(double delta) {
+        this.delta = delta;
     }
 
     @Override

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFPlayer.java
@@ -599,14 +599,20 @@ public abstract class MemoryFPlayer implements FPlayer {
             return;  // don't let dead players regain power until they respawn
         }
 
-        PowerRegenEvent powerRegenEvent = new PowerRegenEvent(getFaction(), this);
+        double delta = millisPassed * Conf.powerPerMinute / 60000; // millisPerMinute : 60 * 1000
+        PowerRegenEvent powerRegenEvent = new PowerRegenEvent(getFaction(), this, delta);
+        
         if (Bukkit.getPluginManager().getPlugin("SavageFactions") != null) {
-            Bukkit.getScheduler().runTask(SavageFactions.plugin, () -> Bukkit.getServer().getPluginManager().callEvent(powerRegenEvent));
-
+            Bukkit.getScheduler().runTask(SavageFactions.plugin, () -> {
+                Bukkit.getServer().getPluginManager().callEvent(powerRegenEvent);
+                
+                if (!powerRegenEvent.isCancelled()) {
+                    this.alterPower(delta);
+                }
+            });
+        } else {
+            this.alterPower(delta);
         }
-
-        if (!powerRegenEvent.isCancelled())
-            this.alterPower(millisPassed * Conf.powerPerMinute / 60000); // millisPerMinute : 60 * 1000
     }
 
     public void losePowerFromBeingOffline() {


### PR DESCRIPTION
This fixed PowerRegenEvent not being cancellable due to it being fired 1 tick later than the check whether it was cancelled.

Also adds the amount of power being regened in the event