### PR TITLE
Allow users to add material whitelist. Warzone/Safezone useage

### DIFF
--- a/src/main/java/com/massivecraft/factions/Conf.java
+++ b/src/main/java/com/massivecraft/factions/Conf.java
@@ -192,12 +192,14 @@ public class Conf {
     public static boolean territoryDenyEndermanBlocksWhenOffline = true;
     public static boolean safeZoneDenyBuild = true;
     public static boolean safeZoneDenyUseage = true;
+    public static Set<Material> safezoneAllowUseageMaterials = new HashSet<>();
     public static boolean safeZoneBlockTNT = true;
     public static boolean safeZonePreventAllDamageToPlayers = false;
     public static boolean safeZoneDenyEndermanBlocks = true;
     public static boolean safeZoneTerritoryDisablePVP = true;
     public static boolean warZoneDenyBuild = true;
     public static boolean warZoneDenyUseage = true;
+    public static Set<Material> warzoneAllowUseageMaterials = new HashSet<>();
     public static boolean warZoneBlockCreepers = false;
     public static boolean warZoneBlockFireballs = false;
     public static boolean warZoneBlockTNT = true;
@@ -573,6 +575,9 @@ public class Conf {
         safeZoneNerfedCreatureTypes.add(EntityType.WITHER);
         safeZoneNerfedCreatureTypes.add(EntityType.ZOMBIE);
 
+        warzoneAllowUseageMaterials.add(XMaterial.FISHING_ROD.parseMaterial());
+
+        safezoneAllowUseageMaterials.add(XMaterial.FISHING_ROD.parseMaterial());
         // Is this called lazy load?
         defaultFactionPermissions.put("COLEADER", new DefaultPermissions(true));
         defaultFactionPermissions.put("MODERATOR", new DefaultPermissions(true));

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -87,11 +87,11 @@ public class FactionsPlayerListener implements Listener {
             if (!justCheck) me.msg(TL.PLAYER_USE_WILDERNESS, TextUtil.getMaterialName(material));
             return false;
         } else if (otherFaction.isSafeZone()) {
-            if (!Conf.safeZoneDenyUseage || Permission.MANAGE_SAFE_ZONE.has(player)) return true;
+            if (!Conf.safeZoneDenyUseage || Permission.MANAGE_SAFE_ZONE.has(player) || Conf.safezoneAllowUseageMaterials.contains(material)) return true;
             if (!justCheck) me.msg(TL.PLAYER_USE_SAFEZONE, TextUtil.getMaterialName(material));
             return false;
         } else if (otherFaction.isWarZone()) {
-            if (!Conf.warZoneDenyUseage || Permission.MANAGE_WAR_ZONE.has(player)) return true;
+            if (!Conf.warZoneDenyUseage || Permission.MANAGE_WAR_ZONE.has(player) || Conf.warzoneAllowUseageMaterials.contains(material)) return true;
             if (!justCheck) me.msg(TL.PLAYER_USE_WARZONE, TextUtil.getMaterialName(material));
             return false;
         }


### PR DESCRIPTION
**What type of PR is this?**  Feature

**Link to relevant issue number(s), if any:** Several users requesting it in Discord support channel.

**Explain your change(s):** Added a list of whitelisted materials in config which can be used in WarZone/Safezone.

**Why did you make these change(s)?** You could not right click blocks with any item. Lots of messages while fighting.

**Is there anything we need to know for compatability?** (variable names, placeholders etc.) No.
