### PR TITLE
Owner perms

### DIFF
--- a/src/main/java/com/massivecraft/factions/Conf.java
+++ b/src/main/java/com/massivecraft/factions/Conf.java
@@ -2,6 +2,7 @@ package com.massivecraft.factions;
 
 import com.google.common.collect.ImmutableMap;
 import com.massivecraft.factions.integration.dynmap.DynmapStyle;
+import com.massivecraft.factions.struct.Relation;
 import com.massivecraft.factions.util.Particles.ParticleEffect;
 import com.massivecraft.factions.util.Particles.Particles;
 import com.massivecraft.factions.util.XMaterial;
@@ -607,6 +608,8 @@ public class Conf {
         defaultFactionPermissions.put("MODERATOR", new DefaultPermissions(true));
         defaultFactionPermissions.put("NORMAL MEMBER", new DefaultPermissions(false));
         defaultFactionPermissions.put("RECRUIT", new DefaultPermissions(false));
+        defaultFactionPermissions.put("ENEMY", new DefaultPermissions(false));
+        defaultFactionPermissions.put("OWNERCLAIM", new DefaultPermissions(false));
     }
 
 

--- a/src/main/java/com/massivecraft/factions/Faction.java
+++ b/src/main/java/com/massivecraft/factions/Faction.java
@@ -244,6 +244,8 @@ public interface Faction extends EconomyParticipator {
 
     Access getAccess(FPlayer player, PermissableAction permissableAction);
 
+    Access getOwnerclaimAccess(FPlayer fplayer, PermissableAction permissableAction);
+
     boolean setPermission(Permissable permissable, PermissableAction permissableAction, Access access);
 
     void resetPerms();

--- a/src/main/java/com/massivecraft/factions/cmd/CmdOwner.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdOwner.java
@@ -12,6 +12,7 @@ public class CmdOwner extends FCommand {
     public CmdOwner() {
         super();
         this.aliases.add("owner");
+        this.aliases.add("private-claim");
         this.optionalArgs.put("player name", "you");
 
         this.requirements = new CommandRequirements.Builder(Permission.OWNER)

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsBlockListener.java
@@ -85,7 +85,7 @@ public class FactionsBlockListener implements Listener {
 
     private static boolean CheckPlayerAccess(Player player, FPlayer me, FLocation loc, Faction myFaction, Access access, PermissableAction action, boolean shouldHurt) {
         boolean landOwned = (myFaction.doesLocationHaveOwnersSet(loc) && !myFaction.getOwnerList(loc).isEmpty());
-        if ((landOwned && myFaction.getOwnerListString(loc).contains(player.getName())) || (me.getRole() == Role.LEADER && me.getFactionId().equals(myFaction.getId())))
+        if ((landOwned && myFaction.getOwnerListString(loc).contains(player.getName()) && myFaction.getOwnerclaimAccess(me, action) == Access.ALLOW) || (me.getRole() == Role.LEADER && me.getFactionId().equals(myFaction.getId())))
             return true;
         else if (landOwned && !myFaction.getOwnerListString(loc).contains(player.getName())) {
             me.msg(TL.ACTIONS_OWNEDTERRITORYDENY.toString().replace("{owners}", myFaction.getOwnerListString(loc)));

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -226,7 +226,8 @@ public class FactionsPlayerListener implements Listener {
         boolean doPain = pain || Conf.handleExploitInteractionSpam; // Painbuild should take priority. But we want to use exploit interaction as well.
         if (access != null) {
             boolean landOwned = (factionToCheck.doesLocationHaveOwnersSet(loc) && !factionToCheck.getOwnerList(loc).isEmpty());
-            if ((landOwned && factionToCheck.getOwnerListString(loc).contains(player.getName())) || (me.getRole() == Role.LEADER && me.getFactionId().equals(factionToCheck.getId()))) {
+            if ((landOwned && factionToCheck.getOwnerListString(loc).contains(player.getName()) && me.getFaction().getOwnerclaimAccess(me, action) == Access.ALLOW)
+                    || (me.getRole() == Role.LEADER && me.getFactionId().equals(factionToCheck.getId()))) {
                 return true;
             } else if (landOwned && !factionToCheck.getOwnerListString(loc).contains(player.getName())) {
                 me.msg(TL.ACTIONS_OWNEDTERRITORYDENY, factionToCheck.getOwnerListString(loc));

--- a/src/main/java/com/massivecraft/factions/struct/Relation.java
+++ b/src/main/java/com/massivecraft/factions/struct/Relation.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 
 public enum Relation implements Permissable {
+    OWNERCLAIM(5, TL.RELATION_OWNERCLAIM_SINGULAR.toString()),
     MEMBER(4, TL.RELATION_MEMBER_SINGULAR.toString()),
     ALLY(3, TL.RELATION_ALLY_SINGULAR.toString()),
     TRUCE(2, TL.RELATION_TRUCE_SINGULAR.toString()),
@@ -38,11 +39,14 @@ public enum Relation implements Permissable {
             return ALLY;
         } else if (s.equalsIgnoreCase(TRUCE.nicename)) {
             return TRUCE;
+        } else if (s.equalsIgnoreCase(OWNERCLAIM.nicename)) {
+            return OWNERCLAIM;
         } else if (s.equalsIgnoreCase(ENEMY.nicename)) {
             return ENEMY;
         } else {
             return NEUTRAL; // If they somehow mess things up, go back to default behavior.
         }
+
     }
 
     @Override
@@ -68,7 +72,7 @@ public enum Relation implements Permissable {
     }
 
     public boolean isMember() {
-        return this == MEMBER;
+        return this == MEMBER || this == OWNERCLAIM;
     }
 
     public boolean isAlly() {
@@ -98,6 +102,8 @@ public enum Relation implements Permissable {
     public ChatColor getColor() {
 
         switch (this) {
+            // Just use member chat color since its ownerclaim member ( its just used for /f perms ).
+            case OWNERCLAIM:
             case MEMBER:
                 return Conf.colorMember;
             case ALLY:

--- a/src/main/java/com/massivecraft/factions/util/PermissionsMapTypeAdapter.java
+++ b/src/main/java/com/massivecraft/factions/util/PermissionsMapTypeAdapter.java
@@ -76,6 +76,7 @@ public class PermissionsMapTypeAdapter implements JsonDeserializer<Map<Permissab
             } else if (Relation.fromString(name.toUpperCase()) != null) {
                 return Relation.fromString(name.toUpperCase());
             } else {
+                System.out.println("BRUH: " + name);
                 return null;
             }
         } else {

--- a/src/main/java/com/massivecraft/factions/zcore/fperms/gui/PermissableRelationFrame.java
+++ b/src/main/java/com/massivecraft/factions/zcore/fperms/gui/PermissableRelationFrame.java
@@ -42,6 +42,7 @@ public class PermissableRelationFrame {
                 e.setCancelled(true);
                 // Closing and opening resets the cursor.
                 // e.getWhoClicked().closeInventory();
+                System.out.println(getPermissable(key));
                 new PermissableActionFrame(fplayer.getFaction()).buildGUI(fplayer, getPermissable(key));
             }));
         }

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
@@ -710,6 +710,19 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
 		return Access.DENY;
 	}
 
+
+	public Access getOwnerclaimAccess(FPlayer fplayer, PermissableAction permissableAction) {
+		if (fplayer == null || permissableAction == null) return Access.DENY;
+
+
+		Map<PermissableAction, Access> accessMap = permissions.get(Relation.OWNERCLAIM);
+		if (accessMap != null && accessMap.containsKey(permissableAction)) {
+			return accessMap.get(permissableAction);
+		}
+
+		return Access.DENY;
+	}
+
 	public boolean setPermission(Permissable permissable, PermissableAction permissableAction, Access access) {
 		if (Conf.useLockedPermissions && Conf.lockedPermissions.contains(permissableAction)) return false;
 		Map<PermissableAction, Access> accessMap = permissions.get(permissable);

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -946,6 +946,7 @@ public enum TL {
 	/**
 	 * Relations
 	 */
+	RELATION_OWNERCLAIM_SINGULAR("ownerclaim"),
 	RELATION_MEMBER_SINGULAR("member"),
 	RELATION_MEMBER_PLURAL("members"),
 	RELATION_ALLY_SINGULAR("ally"),

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -429,6 +429,7 @@ fperm-gui:
         ally: 21
         enemy: 23
         neutral: 25
+        ownerclaim: 31
       # Material to be displayed
       materials:
         recruit: WOOD_SWORD
@@ -439,6 +440,7 @@ fperm-gui:
         ally: GOLD_AXE
         enemy: DIAMOND_AXE
         neutral: WOOD_AXE
+        ownerclaim: STONE_AXE
       Placeholder-Item:
         Name: '&cClick to edit {relation} permissions!'
     action:


### PR DESCRIPTION
**What type of PR is this?**  (Feature, Bug fix, Formatting etc.)
Feature, to implement /f perms access for ownerclaims
**Link to relevant issue number(s), if any:**
N/A
**Explain your change(s):**
I added a new relation that is just meant to be used by the F perms system called OWNERCLAIM, I made it return the same thing as MEMBER for all cases other than f perms where it is different. 

The /f perms gui now generates a menu item with a stone axe for editing ownerclaim permissions.
**Why did you make these change(s)?**
Geumu requested it.
**Is there anything we need to know for compatability?** (variable names, placeholders etc.)

![image](https://user-images.githubusercontent.com/29169519/69490920-e11bee80-0e53-11ea-8970-8a71ef73f7f9.png)

![image](https://user-images.githubusercontent.com/29169519/69490925-eda04700-0e53-11ea-847b-d495cbb13d86.png)
