### PR TITLE
Invert econ transaction amounts at the beginning if zero

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/money/CmdMoneyDeposit.java
+++ b/src/main/java/com/massivecraft/factions/cmd/money/CmdMoneyDeposit.java
@@ -30,6 +30,7 @@ public class CmdMoneyDeposit extends FCommand {
     @Override
     public void perform(CommandContext context) {
         double amount = context.argAsDouble(0, 0d);
+        if (amount < 0) amount = amount * -1;
         EconomyParticipator faction = context.argAsFaction(1, context.faction);
         if (faction == null) {
             return;

--- a/src/main/java/com/massivecraft/factions/cmd/money/CmdMoneyTransferFf.java
+++ b/src/main/java/com/massivecraft/factions/cmd/money/CmdMoneyTransferFf.java
@@ -29,6 +29,7 @@ public class CmdMoneyTransferFf extends FCommand {
     @Override
     public void perform(CommandContext context) {
         double amount = context.argAsDouble(0, 0d);
+        if (amount < 0) amount = amount * -1;
         EconomyParticipator from = context.argAsFaction(1);
         if (from == null) {
             return;

--- a/src/main/java/com/massivecraft/factions/cmd/money/CmdMoneyTransferFp.java
+++ b/src/main/java/com/massivecraft/factions/cmd/money/CmdMoneyTransferFp.java
@@ -26,6 +26,7 @@ public class CmdMoneyTransferFp extends FCommand {
     @Override
     public void perform(CommandContext context) {
         double amount = context.argAsDouble(0, 0d);
+        if (amount < 0) amount = amount * -1;
         EconomyParticipator from = context.argAsFaction(1);
         if (from == null) {
             return;

--- a/src/main/java/com/massivecraft/factions/cmd/money/CmdMoneyTransferPf.java
+++ b/src/main/java/com/massivecraft/factions/cmd/money/CmdMoneyTransferPf.java
@@ -27,6 +27,7 @@ public class CmdMoneyTransferPf extends FCommand {
     @Override
     public void perform(CommandContext context) {
         double amount = context.argAsDouble(0, 0d);
+        if (amount < 0) amount = amount * -1;
         EconomyParticipator from = context.argAsBestFPlayerMatch(1);
         if (from == null) {
             return;

--- a/src/main/java/com/massivecraft/factions/cmd/money/CmdMoneyWithdraw.java
+++ b/src/main/java/com/massivecraft/factions/cmd/money/CmdMoneyWithdraw.java
@@ -32,6 +32,7 @@ public class CmdMoneyWithdraw extends FCommand {
     @Override
     public void perform(CommandContext context) {
         double amount = context.argAsDouble(0, 0d);
+        if (amount < 0) amount = amount * -1;
         EconomyParticipator faction = context.argAsFaction(1, context.faction);
         if (faction == null) {
             return;


### PR DESCRIPTION
**What type of PR is this?**  (Feature, Bug fix, Formatting etc.)
Bug Fix/Formatting.
**Link to relevant issue number(s), if any:**
N/A - someone asked me about this on discord.
**Explain your change(s):**
I inverted each amount variable in the commands if the amount was less than zero.
**Why did you make these change(s)?**
The formatting would show negative amounts.
**Is there anything we need to know for compatability?** (variable names, placeholders etc.)
N/A